### PR TITLE
Add admonition line separation rule

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -19,12 +19,14 @@ mod rule002_admonition_types;
 mod rule003_spelling;
 mod rule004_exclude_words;
 mod rule005_admonition_newlines;
+mod rule006_admonition_line_separation;
 
 pub use rule001_heading_case::Rule001HeadingCase;
 pub use rule002_admonition_types::Rule002AdmonitionTypes;
 pub use rule003_spelling::Rule003Spelling;
 pub use rule004_exclude_words::Rule004ExcludeWords;
 pub use rule005_admonition_newlines::Rule005AdmonitionNewlines;
+pub use rule006_admonition_line_separation::Rule006AdmonitionLineSeparation;
 
 fn get_all_rules() -> Vec<Box<dyn Rule>> {
     vec![
@@ -33,6 +35,7 @@ fn get_all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(Rule003Spelling::default()),
         Box::new(Rule004ExcludeWords::default()),
         Box::new(Rule005AdmonitionNewlines),
+        Box::new(Rule006AdmonitionLineSeparation::default()),
     ]
 }
 

--- a/src/rules/rule006_admonition_line_separation.rs
+++ b/src/rules/rule006_admonition_line_separation.rs
@@ -1,0 +1,124 @@
+use log::debug;
+use markdown::mdast::Node;
+use supa_mdx_macros::RuleName;
+
+use crate::{
+    context::Context,
+    errors::{LintError, LintLevel},
+    fix::{LintCorrection, LintCorrectionInsert},
+    location::{AdjustedRange, DenormalizedLocation},
+};
+
+use super::{Rule, RuleName, RuleSettings};
+
+/// Ensure lines inside admonitions are separated by blank lines.
+#[derive(Debug, Default, RuleName)]
+pub struct Rule006AdmonitionLineSeparation;
+
+impl Rule for Rule006AdmonitionLineSeparation {
+    fn default_level(&self) -> LintLevel {
+        LintLevel::Error
+    }
+
+    fn setup(&mut self, _settings: Option<&mut RuleSettings>) {}
+
+    fn check(&self, ast: &Node, context: &Context, level: LintLevel) -> Option<Vec<LintError>> {
+        if let Node::MdxJsxFlowElement(element) = ast {
+            if element
+                .name
+                .as_ref()
+                .is_some_and(|name| name == "Admonition")
+            {
+                if let Some(error) = self.check_admonition(element, context, level) {
+                    return Some(vec![error]);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Rule006AdmonitionLineSeparation {
+    fn check_admonition(
+        &self,
+        element: &markdown::mdast::MdxJsxFlowElement,
+        context: &Context,
+        level: LintLevel,
+    ) -> Option<LintError> {
+        if element.children.is_empty() {
+            return None;
+        }
+
+        let position = element.position.as_ref()?;
+        let adjusted_range = AdjustedRange::from_unadjusted_position(position, context);
+
+        let rope = context.rope();
+        let range: std::ops::Range<usize> = adjusted_range.clone().into();
+        let content = rope.byte_slice(range).to_string();
+        debug!("Admonition content: {:?}", content);
+
+        if let Some(fixes) = self.generate_fixes(&content, &adjusted_range, context) {
+            let location =
+                DenormalizedLocation::from_offset_range(adjusted_range, context);
+            return Some(
+                LintError::from_raw_location()
+                    .rule(self.name())
+                    .message("Lines in admonitions must be separated by blank lines")
+                    .level(level)
+                    .location(location)
+                    .fix(fixes)
+                    .call(),
+            );
+        }
+
+        None
+    }
+
+    fn generate_fixes(
+        &self,
+        content: &str,
+        adjusted_range: &AdjustedRange,
+        context: &Context,
+    ) -> Option<Vec<LintCorrection>> {
+        let lines: Vec<&str> = content.lines().collect();
+        if lines.len() < 3 {
+            return None;
+        }
+
+        let line_ending = if content.contains("\r\n") { "\r\n" } else { "\n" };
+        let line_ending_len = line_ending.len();
+        let mut fixes = Vec::new();
+        let mut offset = lines[0].len() + line_ending_len;
+        let mut last_was_content = false;
+
+        for line in &lines[1..] {
+            if line.trim_start().starts_with("</Admonition") {
+                break;
+            }
+            if line.trim().is_empty() {
+                last_was_content = false;
+                offset += line.len() + line_ending_len;
+                continue;
+            }
+            if last_was_content {
+                let mut start = adjusted_range.start;
+                start.increment(offset);
+                let location = DenormalizedLocation::from_offset_range(
+                    AdjustedRange::new(start, start),
+                    context,
+                );
+                fixes.push(LintCorrection::Insert(LintCorrectionInsert {
+                    location,
+                    text: line_ending.to_string(),
+                }));
+                offset += line.len() + line_ending_len;
+                last_was_content = true; // already set
+                continue;
+            }
+            last_was_content = true;
+            offset += line.len() + line_ending_len;
+        }
+
+        if fixes.is_empty() { None } else { Some(fixes) }
+    }
+}

--- a/src/snapshots/supa_mdx_lint__tests__public_api.snap
+++ b/src/snapshots/supa_mdx_lint__tests__public_api.snap
@@ -565,6 +565,34 @@ pub fn supa_mdx_lint::rules::Rule005AdmonitionNewlines::borrow_mut(&mut self) ->
 impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule005AdmonitionNewlines
 pub fn supa_mdx_lint::rules::Rule005AdmonitionNewlines::from(t: T) -> T
 impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule005AdmonitionNewlines
+pub struct supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::default::Default for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::default() -> supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::marker::Send for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::marker::Sync for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
+pub fn supa_mdx_lint::rules::Rule006AdmonitionLineSeparation::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule006AdmonitionLineSeparation
 pub enum supa_mdx_lint::LintLevel
 pub supa_mdx_lint::LintLevel::Error
 pub supa_mdx_lint::LintLevel::Warning

--- a/tests/autofix_tests.rs
+++ b/tests/autofix_tests.rs
@@ -219,3 +219,38 @@ This one is missing the opening newline.
 </Admonition>"#
     );
 }
+
+#[test]
+fn test_autofix_rule006_admonition_line_separation() {
+    let tempdir = TempDir::new().unwrap();
+    let bad_file = r#"# Test admonition line separation
+
+<Admonition type=\"note\">
+
+This admonition has multiple lines.
+That are only separated by a single line break.
+
+</Admonition>"#;
+    fs::write(tempdir.path().join("bad.mdx"), bad_file).unwrap();
+
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg(tempdir.path().join("bad.mdx"))
+        .arg("--config")
+        .arg("tests/supa-mdx-lint.config.toml")
+        .arg("--fix");
+    cmd.assert().success();
+
+    let result = fs::read_to_string(tempdir.path().join("bad.mdx")).unwrap();
+    assert_eq!(
+        result,
+        r#"# Test admonition line separation
+
+<Admonition type=\"note\">
+
+This admonition has multiple lines.
+
+That are only separated by a single line break.
+
+</Admonition>"#
+    );
+}

--- a/tests/rule006/mod.rs
+++ b/tests/rule006/mod.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn integration_test_rule006() {
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg("tests/rule006/rule006.mdx")
+        .arg("--config")
+        .arg("tests/rule006/supa-mdx-lint.config.toml");
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("1 error"))
+        .stdout(predicate::str::contains("Rule006AdmonitionLineSeparation"));
+}

--- a/tests/rule006/rule006.mdx
+++ b/tests/rule006/rule006.mdx
@@ -1,0 +1,9 @@
+# Test admonition line separation
+
+<Admonition type="note">
+
+This admonition has multiple lines.
+That are only separated by a single line break.
+
+</Admonition>
+

--- a/tests/rule006/supa-mdx-lint.config.toml
+++ b/tests/rule006/supa-mdx-lint.config.toml
@@ -1,0 +1,5 @@
+Rule001HeadingCase = false
+Rule002AdmonitionTypes = false
+Rule003Spelling = false
+Rule004ExcludeWords = false
+Rule005AdmonitionNewlines = false

--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -1,3 +1,4 @@
 mod rule002;
 mod rule003;
 mod rule004;
+mod rule006;


### PR DESCRIPTION
## Summary
- enforce blank line separation inside admonitions
- wire new rule into rule registry and API snapshot
- add integration and autofix tests for rule006

## Testing
- `cargo test -- --test-threads=1` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6866e0087f388326b2bb2e055184ea3f