### PR TITLE
Fix regex to support CRLF newline formatting

### DIFF
--- a/src/rules/rule005_admonition_newlines.rs
+++ b/src/rules/rule005_admonition_newlines.rs
@@ -20,7 +20,8 @@ struct ErrorInfo {
 }
 
 static ADMONITION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?s)<Admonition[^>]*>\s*\n\s*\n.*?\n\s*\n\s*</Admonition>").unwrap()
+    Regex::new(r"(?s)<Admonition[^>]*>\s*\r?\n\s*\r?\n.*?\r?\n\s*\r?\n\s*</Admonition>")
+        .unwrap()
 });
 
 /// Admonition JSX tags must have empty line separation from their content.


### PR DESCRIPTION
## Summary
- ensure `Rule005AdmonitionNewlines` allows CRLF line endings by updating the regex

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_6866df4d89748326bf6a539eed9001ca